### PR TITLE
Adds support for Action Scheduler handling

### DIFF
--- a/adminpages/settings.php
+++ b/adminpages/settings.php
@@ -5,6 +5,8 @@
 	}
 
 	global $msg, $msgt, $pmprodev_options;
+	$pmpro_db_version = get_option( 'pmpro_db_version' );
+
 
 	// Bail if nonce field isn't set.
 	if ( !empty( $_REQUEST['savesettings'] ) && ( empty( $_REQUEST[ 'pmpro_toolkit_nonce' ] ) 
@@ -36,6 +38,13 @@
 		}
 
 		$pmprodev_options['expiration_warnings'] = $expiration_warnings;
+
+		if( isset( $_POST['pmprodev_options']['payment_reminders'] ) ) {
+			$payment_reminders = intval( $_POST['pmprodev_options']['payment_reminders'] );
+		} else {
+			$payment_reminders = 0;
+		}
+		$pmprodev_options['payment_reminders'] = $payment_reminders;
 
 		if( isset( $_POST['pmprodev_options']['credit_card_expiring'] ) ) {
 			$credit_card_expiring = intval( $_POST['pmprodev_options']['credit_card_expiring'] );
@@ -100,7 +109,11 @@
 		<div class="pmpro_section_toggle">
 			<button class="pmpro_section-toggle-button" type="button" aria-expanded="true">
 				<span class="dashicons dashicons-arrow-up-alt2"></span>
-				<?php esc_html_e( 'Scheduled Cron Job Debugging', 'pmpro-toolkit' ); ?>
+					<?php if ( class_exists( 'PMPro_Scheduled_Actions' ) ) { ?>
+					<?php esc_html_e( 'Scheduled Actions Debugging', 'pmpro-toolkit' ); ?>
+				<?php } else { ?>
+					<?php esc_html_e( 'Scheduled Cron Job Debugging', 'pmpro-toolkit' ); ?>
+				<?php } ?>
 			</button>
 		</div>
 		<div class="pmpro_section_inside">
@@ -130,7 +143,20 @@
 							</label>
 						</td>
 					<tr>
-					<!-- another row but for Credit Card Expiring -->
+					<!-- another row but for Payment Reminders -->
+					<tr>
+						<th scope="row" valign="top">
+							<label for="payment_reminders"><?php esc_html_e( 'Payment Reminders', 'pmpro-toolkit' ); ?></label>
+						</th>
+						<td>
+							<input id="payment_reminders" type="checkbox" name="pmprodev_options[payment_reminders]" value="1" <?php checked( $pmprodev_options['payment_reminders'], 1, true ); ?>>
+							<label for="payment_reminders">
+								<?php esc_html_e( 'Check to disable the script that sends payment reminders.', 'pmpro-toolkit' ); ?>
+							</label>
+						</td>
+					<tr>
+					<!-- another row but for Credit Card Expiring in older versions -->
+					<?php if ( $pmpro_db_version < 3.4 ) { ?>
 					<tr>
 						<th scope="row" valign="top">
 							<label for="credit_card_expiring"><?php esc_html_e( 'Credit Card Expiring', 'pmpro-toolkit' ); ?></label>
@@ -142,6 +168,7 @@
 							</label>
 						</td>
 					</tr>
+					<?php } ?>
 				</tbody>
 			</table>
 		</div>

--- a/pmpro-toolkit.php
+++ b/pmpro-toolkit.php
@@ -16,6 +16,7 @@ global $pmprodev_options, $gateway;
 $default_options = array(
 	'expire_memberships' => '',
 	'expiration_warnings' => '',
+	'payment_reminders' => '',
 	'credit_card_expiring' => '',
 	'ipn_debug' => '',
 	'authnet_silent_post_debug' => '',
@@ -80,15 +81,32 @@ function pmprodev_gateway_debug_setup() {
 		define( 'PMPRO_INS_DEBUG', $pmprodev_options['ipn_debug'] );
 	}
 
-	//unhook crons
+	// Unhook crons or Action Scheduler actions
 	if( !empty( $pmprodev_options['expire_memberships'] ) ) {
-		remove_action( "pmpro_cron_expire_memberships", "pmpro_cron_expire_memberships" );
+		if ( class_exists( 'PMPro_Scheduled_Actions' ) ) {
+			remove_action( 'pmpro_schedule_daily', array( PMPro_Scheduled_Actions::instance(), 'membership_expiration_reminders' ), 10 );
+		} else {
+			remove_action( "pmpro_cron_expire_memberships", "pmpro_cron_expire_memberships" );
+		}
 	}
 
-	if( !empty( $pmprodev_options['expiration_warnings'] ) )	{
-		remove_action( "pmpro_cron_expiration_warnings", "pmpro_cron_expiration_warnings" );
+	if( !empty( $pmprodev_options['expiration_warnings'] ) ){
+		if ( class_exists( 'PMPro_Scheduled_Actions' ) ) {
+			remove_action( 'pmpro_schedule_daily', array( PMPro_Scheduled_Actions::instance(), 'membership_expiration_warnings' ), 10 );
+		} else {
+			remove_action( "pmpro_cron_expiration_warnings", "pmpro_cron_expiration_warnings" );
+		}
 	}
 
+	if( !empty( $pmprodev_options['payment_reminders'] ) ){
+		if ( class_exists( 'PMPro_Scheduled_Actions' ) ) {
+			remove_action( 'pmpro_schedule_daily', array( PMPro_Scheduled_Actions::instance(), 'recurring_payment_reminders' ), 10 );
+		} else {
+			remove_action( "pmpro_cron_recurring_payment_reminders", "pmpro_cron_recurring_payment_reminders" );
+		}
+	}
+
+	// Backward compatibility with older PMPro versions
 	if( !empty( $pmprodev_options['credit_card_expiring'] ) ) {
 		remove_action( "pmpro_cron_credit_card_expiring_warnings", "pmpro_cron_credit_card_expiring_warnings" );
 	}


### PR DESCRIPTION


- Adds conditional support for handling _Action Scheduler_ (will be in a future release of PMPro) if present
- Removes admin setting for credit card expiration reminders in newer versions of PMPro (has been deprecated for awhile)
- Adds admin setting for payment reminders emails (when using _Action Scheduler_ or `wp-cron`)