### PR TITLE
Delete test subscriptions when deleting test orders.

### DIFF
--- a/adminpages/scripts.php
+++ b/adminpages/scripts.php
@@ -53,7 +53,7 @@ $clean_up_actions = array(
 	),
 	'pmprodev_delete_test_orders' => array(
 		'label' => __( 'Delete Test Orders', 'pmpro-toolkit' ),
-		'description' => __( 'Delete all orders made through the testing or sandbox gateway environment. This includes any associated test subscriptions that may have been created as part of those orders.', 'pmpro-toolkit' ),
+		'description' => __( 'Delete all orders made through the testing or sandbox gateway environment. This includes any test subscriptions.', 'pmpro-toolkit' ),
 		'message' => __( 'Test orders deleted.', 'pmpro-toolkit' )
 	),
 	'pmprodev_clear_cached_report_data' => array(
@@ -448,17 +448,9 @@ function pmprodev_clear_vvl_report( $message ) {
  */
 function pmprodev_delete_test_orders( $message ) {
 	global $wpdb;
-
-	// Delete subscriptions linked to sandbox orders only. 
-	$wpdb->query( 
-		"DELETE s FROM {$wpdb->pmpro_subscriptions} s
-		INNER JOIN {$wpdb->pmpro_membership_orders} o
-		ON s.subscription_transaction_id = o.subscription_transaction_id
-		WHERE o.gateway_environment = 'sandbox'"
-	);
-
-	// Delete the test orders now.
+	// Delete the test orders now and sandbox subscriptions.
 	$wpdb->query( "DELETE FROM {$wpdb->pmpro_membership_orders} WHERE gateway_environment = 'sandbox'" );
+	$wpdb->query( "DELETE FROM {$wpdb->pmpro_subscriptions} WHERE gateway_environment = 'sandbox'" );
 	pmprodev_output_message( $message );
 }
 


### PR DESCRIPTION
* ENHANCEMENT: Delete test subscriptions from the subscriptions table when deleting test orders.

The more simplified version of this SQL would be to delete all subscriptions from the subscriptions table where the gateway environment is sandbox. It felt like a better solution to ensure we only deleting test subscriptions that are linked to test orders and then delete the test orders.

This won't delete subscriptions that may have been added manually or programmatically. Which feels like the right decision here, in case there are custom subscriptions.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-toolkit/pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Checkout for a recurring level (Stripe) in sandbox mode and ensure the subscriptions are created.
2. Run the Delete Test Orders script from Toolkit
3. See that the test order and the associated subscription is deleted.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?