### PR TITLE
Rename namespace and adjust text-domain

### DIFF
--- a/classes/api/Abstract_API_Endpoint.php
+++ b/classes/api/Abstract_API_Endpoint.php
@@ -1,7 +1,7 @@
 <?php
 
 // Toolkit
-namespace TK;
+namespace PMPro_Toolkit;
 
 use WP_REST_Request;
 use WP_REST_Response;

--- a/classes/api/Example_Endpoint.php
+++ b/classes/api/Example_Endpoint.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TK;
+namespace PMPro_Toolkit;
 
 use WP_REST_Request;
 use WP_REST_Server;

--- a/classes/api/Test_Account_Endpoint.php
+++ b/classes/api/Test_Account_Endpoint.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TK;
+namespace PMPro_Toolkit;
 
 use WP_REST_Request;
 use WP_REST_Server;

--- a/classes/api/Test_Cancel_Level_Endpoint.php
+++ b/classes/api/Test_Cancel_Level_Endpoint.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TK;
+namespace PMPro_Toolkit;
 
 use WP_REST_Request;
 use WP_REST_Server;

--- a/classes/api/Test_Change_Level_Endpoint.php
+++ b/classes/api/Test_Change_Level_Endpoint.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TK;
+namespace PMPro_Toolkit;
 
 use WP_REST_Request;
 use WP_REST_Server;

--- a/classes/api/Test_Checkout_Endpoint.php
+++ b/classes/api/Test_Checkout_Endpoint.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TK;
+namespace PMPro_Toolkit;
 
 use WP_REST_Request;
 use WP_REST_Server;
@@ -88,7 +88,7 @@ class Test_Checkout_Endpoint extends API_Endpoint {
 		if ( ! pmpro_getLevel( $level_id ) ) {
 			return $this->json_error(
 				'invalid_level',
-				sprintf( __( 'Membership level ID %d does not exist.', 'tk' ), $level_id ),
+				sprintf( __( 'Membership level ID %d does not exist.', 'pmpro-toolkit' ), $level_id ),
 				400
 			);
 		}
@@ -97,7 +97,7 @@ class Test_Checkout_Endpoint extends API_Endpoint {
 		if ( ! $this->is_valid_mysql_datetime( $checkout_date ) ) {
 			return $this->json_error(
 				'invalid_date',
-				__( 'checkout_date must be in MySQL datetime format (YYYY-MM-DD HH:MM:SS).', 'tk' ),
+				__( 'checkout_date must be in MySQL datetime format (YYYY-MM-DD HH:MM:SS).', 'pmpro-toolkit' ),
 				400
 			);
 		}
@@ -116,7 +116,7 @@ class Test_Checkout_Endpoint extends API_Endpoint {
 				return $this->json_error(
 					'user_has_membership',
 					sprintf(
-						__( 'User %1$s already has membership level %2$d.', 'tk' ),
+						__( 'User %1$s already has membership level %2$d.', 'pmpro-toolkit' ),
 						$user_data['user_login'],
 						$level_id
 					),
@@ -186,38 +186,38 @@ class Test_Checkout_Endpoint extends API_Endpoint {
 	private function get_endpoint_args() {
 		return array(
 			'membership_level' => array(
-				'description' => __( 'Membership level ID to test.', 'tk' ),
+				'description' => __( 'Membership level ID to test.', 'pmpro-toolkit' ),
 				'type'        => 'integer',
 				'default'     => 1,
 				'minimum'     => 1,
 			),
 			'gateway'          => array(
-				'description' => __( 'Payment gateway to use.', 'tk' ),
+				'description' => __( 'Payment gateway to use.', 'pmpro-toolkit' ),
 				'type'        => 'string',
 				'default'     => 'check',
 				'enum'        => array( 'check', 'stripe', 'paypal', 'authorizenet' ),
 			),
 			'skip_gateway'     => array(
-				'description' => __( 'Skip remote gateway calls for local profiling.', 'tk' ),
+				'description' => __( 'Skip remote gateway calls for local profiling.', 'pmpro-toolkit' ),
 				'type'        => 'boolean',
 				'default'     => false,
 			),
 			'cleanup'          => array(
-				'description' => __( 'Delete test user and data after checkout.', 'tk' ),
+				'description' => __( 'Delete test user and data after checkout.', 'pmpro-toolkit' ),
 				'type'        => 'boolean',
 				'default'     => false,
 			),
 			'checkout_date'    => array(
-				'description' => __( 'Custom checkout date for backdating (MySQL datetime format).', 'tk' ),
+				'description' => __( 'Custom checkout date for backdating (MySQL datetime format).', 'pmpro-toolkit' ),
 				'type'        => 'string',
 				'format'      => 'date-time',
 			),
 			'user_login'       => array(
-				'description' => __( 'Custom username for test user.', 'tk' ),
+				'description' => __( 'Custom username for test user.', 'pmpro-toolkit' ),
 				'type'        => 'string',
 			),
 			'user_email'       => array(
-				'description' => __( 'Custom email for test user.', 'tk' ),
+				'description' => __( 'Custom email for test user.', 'pmpro-toolkit' ),
 				'type'        => 'string',
 				'format'      => 'email',
 			),
@@ -250,7 +250,7 @@ class Test_Checkout_Endpoint extends API_Endpoint {
 			if ( ! $random_user ) {
 				return $this->json_error(
 					'random_user_failed',
-					__( 'Could not generate test user data. Random user API is unavailable.', 'tk' ),
+					__( 'Could not generate test user data. Random user API is unavailable.', 'pmpro-toolkit' ),
 					503
 				);
 			}
@@ -271,7 +271,7 @@ class Test_Checkout_Endpoint extends API_Endpoint {
 		if ( empty( $username ) || empty( $user_email ) ) {
 			return $this->json_error(
 				'invalid_user_data',
-				__( 'Valid user_login and user_email are required.', 'tk' ),
+				__( 'Valid user_login and user_email are required.', 'pmpro-toolkit' ),
 				400
 			);
 		}
@@ -279,7 +279,7 @@ class Test_Checkout_Endpoint extends API_Endpoint {
 		if ( ! is_email( $user_email ) ) {
 			return $this->json_error(
 				'invalid_email',
-				__( 'user_email must be a valid email address.', 'tk' ),
+				__( 'user_email must be a valid email address.', 'pmpro-toolkit' ),
 				400
 			);
 		}

--- a/classes/api/Test_General_Endpoint.php
+++ b/classes/api/Test_General_Endpoint.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TK;
+namespace PMPro_Toolkit;
 
 use WP_REST_Request;
 use WP_REST_Server;

--- a/classes/api/Test_Login_Endpoint.php
+++ b/classes/api/Test_Login_Endpoint.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TK;
+namespace PMPro_Toolkit;
 
 use WP_REST_Request;
 use WP_REST_Server;

--- a/classes/api/Test_Member_Export_Endpoint.php
+++ b/classes/api/Test_Member_Export_Endpoint.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace TK;
+namespace PMPro_Toolkit;
 
-use TK\API_Endpoint;
+use PMPro_Toolkit\API_Endpoint;
 use WP_REST_Request;
 use WP_REST_Response;
 

--- a/classes/api/Test_Report_Endpoint.php
+++ b/classes/api/Test_Report_Endpoint.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace TK;
+namespace PMPro_Toolkit;
 
-use TK\API_Endpoint;
+use PMPro_Toolkit\API_Endpoint;
 use WP_REST_Request;
 use WP_REST_Response;
 

--- a/classes/api/Test_Search_Endpoint.php
+++ b/classes/api/Test_Search_Endpoint.php
@@ -1,9 +1,9 @@
 <?php
 
 // Toolkit
-namespace TK;
+namespace PMPro_Toolkit;
 
-use TK\API_Endpoint;
+use PMPro_Toolkit\API_Endpoint;
 use WP_REST_Request;
 use WP_REST_Response;
 

--- a/classes/class-api-loader.php
+++ b/classes/class-api-loader.php
@@ -2,20 +2,20 @@
 /**
  * API Loader class.
  *
- * @package TK
+ * @package PMPro_Toolkit
  */
 
-namespace TK;
+namespace PMPro_Toolkit;
 
-use TK\Test_General_Endpoint;
-use TK\Test_Login_Endpoint;
-use TK\Test_Checkout_Endpoint;
-use TK\Test_Change_Level_Endpoint;
-use TK\Test_Membership_Account_Endpoint;
-use TK\Test_Cancel_Level_Endpoint;
-use TK\Test_Search_Endpoint;
-use TK\Test_Report_Endpoint;
-use TK\Test_Member_Export_Endpoint;
+use PMPro_Toolkit\Test_General_Endpoint;
+use PMPro_Toolkit\Test_Login_Endpoint;
+use PMPro_Toolkit\Test_Checkout_Endpoint;
+use PMPro_Toolkit\Test_Change_Level_Endpoint;
+use PMPro_Toolkit\Test_Membership_Account_Endpoint;
+use PMPro_Toolkit\Test_Cancel_Level_Endpoint;
+use PMPro_Toolkit\Test_Search_Endpoint;
+use PMPro_Toolkit\Test_Report_Endpoint;
+use PMPro_Toolkit\Test_Member_Export_Endpoint;
 
 class API_Loader {
 	/**

--- a/classes/class-pmprodev-migration-assistant.php
+++ b/classes/class-pmprodev-migration-assistant.php
@@ -65,13 +65,13 @@ class PMProDev_Migration_Assistant {
 		foreach ( $file_data as $import_type => $import_data ) {
 			// Check if we can process this type of import.
 			if ( ! method_exists( __CLASS__, 'import_data_' . $import_type ) ) {
-				$error = empty( $error ) ? __( 'Invalid import type: ', 'pmpro_toolkit' ) . $import_type : $error;
+				$error = empty( $error ) ? __( 'Invalid import type: ', pmpro-toolkit ) . $import_type : $error;
 				continue;
 			}
 
 			// Check that the data being imported is valid.
 			if ( ! is_array( $import_data ) ) {
-				$error = empty( $error ) ? __( 'Invalid import data for import type: ', 'pmpro_toolkit' ) . $import_type : $error;
+				$error = empty( $error ) ? __( 'Invalid import data for import type: ', pmpro-toolkit ) . $import_type : $error;
 				continue;
 			}
 

--- a/classes/traits/Performance_Tracking_Trait.php
+++ b/classes/traits/Performance_Tracking_Trait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TK;
+namespace PMPro_Toolkit;
 
 /**
  * PerformanceTrackingTrait
@@ -8,7 +8,7 @@ namespace TK;
  * This trait provides methods to track performance metrics such as execution time,
  * number of database queries, and peak memory usage.
  *
- * @package TK
+ * @package PMPro_Toolkit
  */
 trait PerformanceTrackingTrait {
 	protected $perf_start_time;

--- a/cli/Toolkit_Commands.php
+++ b/cli/Toolkit_Commands.php
@@ -1,5 +1,5 @@
 <?php
-namespace TK;
+namespace PMPro_Toolkit;
 
 use WP_CLI;
 use WP_CLI_Command;

--- a/pmpro-toolkit.php
+++ b/pmpro-toolkit.php
@@ -82,7 +82,7 @@ if ( ! empty( $pmprodev_options['performance_endpoints'] ) && $pmprodev_options[
 	}
 
 	// Initialize the namespaced API Loader.
-	new TK\API_Loader();
+	new PMPro_Toolkit\API_Loader();
 }
 
 /**
@@ -94,7 +94,7 @@ if ( ! empty( $pmprodev_options['performance_endpoints'] ) && $pmprodev_options[
 if ( defined( 'WP_CLI' ) && WP_CLI && ! empty( $pmprodev_options['enable_cli_commands'] ) ) {
 	// Load CLI command class only if enabled via Toolkit setting.
 	require_once plugin_dir_path( __FILE__ ) . 'cli/Toolkit_Commands.php';
-	\WP_CLI::add_command( 'pmpro-toolkit', 'TK\\Toolkit_Commands' );
+	\WP_CLI::add_command( 'pmpro-toolkit', 'PMPro_Toolkit\\Toolkit_Commands' );
 }
 
 /**


### PR DESCRIPTION
- Adjusted the name space from TK to PMPro_Toolkit to be more verbose.
- Adjusted some incorrect text domains to be `pmpro-toolkit`.