### PR TITLE
General improvements to the rest API tests and guard rails.

### DIFF
--- a/classes/api/Abstract_API_Endpoint.php
+++ b/classes/api/Abstract_API_Endpoint.php
@@ -119,4 +119,35 @@ abstract class API_Endpoint {
 
 		return true;
 	}
+
+	/**
+	 * Check to see if the request's method is allowed based on the performance_endpoints setting.
+	 * This is an extra guard rail to prevent people from using "POST" methods when set to "read_only".
+	 *
+	 * @param string $method The HTTP method of the request (e.g., 'GET', 'POST', etc.).
+	 * @return boolean $allowed True if the method is allowed, false if not.
+	 */	
+	public function is_request_allowed( $method ) {
+		$allowed_methods = $this->check_setting( 'performance_endpoints' );
+		$allowed = false;
+
+		// If method is DELETE, UPDATE or PATCH let's set it to false.
+		if ( in_array( $method, array( 'DELETE', 'PUT', 'PATCH' ), true ) ) {
+			$allowed = false;
+		} elseif ( ! empty( $allowed_methods ) && $allowed_methods === 'read_write' ) {
+			$allowed = true;
+		} elseif ( ! empty( $allowed_methods ) && $allowed_methods === 'read_only' && $method === 'GET' ) {
+			$allowed = true;
+		}
+
+		/**
+		 * Filter to allow customization of whether a request method is allowed for an endpoint.
+		 * This filter passes the current allowed status, the request method, and the allowed methods setting.
+		 * 
+		 * @param bool  $allowed         Whether the request method is allowed.
+		 * @param string $method          The HTTP method of the request.
+		 * @param string $allowed_methods The allowed methods setting ('read_only', 'read_write', 'no').
+		 */
+		return apply_filters( 'pmpro_toolkit_is_request_allowed', $allowed, $method, $allowed_methods );
+	}
 }

--- a/classes/api/Example_Endpoint.php
+++ b/classes/api/Example_Endpoint.php
@@ -7,9 +7,7 @@ use WP_REST_Server;
 use WP_Error;
 
 /**
- * Upload_Failed_Endpoint
- *
- * API endpoint for handling video upload failures
+ * Example endpoint that you may use as a template for new endpoints.
  */
 class Example_Endpoint extends API_Endpoint {
 
@@ -25,7 +23,6 @@ class Example_Endpoint extends API_Endpoint {
 	 * Register the example REST API routes for this endpoint
 	 */
 	public function register_routes() {
-
 		register_rest_route(
 			$this->get_namespace(),
 			'/test-example',
@@ -58,17 +55,29 @@ class Example_Endpoint extends API_Endpoint {
 	 * @return void
 	 */
 	public function handle_request( WP_REST_Request $request ) {
-		$user_id = absint( $request->get_param( 'user_id' ) );
 
+		$method = $request->get_method();
+		if ( ! $this->is_request_allowed( $method ) ) {
+			return $this->json_error(
+				'method_not_allowed',
+				'The ' . $method . ' method is not allowed for this endpoint. Please adjust your toolkit settings.',
+				array( 'status' => 405 )
+			);
+		}
+
+		$user_id = absint( $request->get_param( 'user_id' ) );
 		if ( empty( $user_id ) ) {
-			return new WP_Error( 'invalid_user_id', 'Invalid user ID', array( 'status' => 400 ) );
+			return $this->json_error( 
+				'invalid_user_id',
+				'Invalid user ID',
+				array( 'status' => 400 ) 
+			);
 		}
 
 		// Start performance tracking
 		$this->start_performance_tracking();
 
 		$user = $this->get_user( $user_id );
-
 		if ( ! $user ) {
 			return $this->json_error( 'user_not_found', 'User not found.', 404 );
 		}

--- a/classes/api/Test_Account_Endpoint.php
+++ b/classes/api/Test_Account_Endpoint.php
@@ -6,6 +6,9 @@ use WP_REST_Request;
 use WP_REST_Server;
 use WP_Error;
 
+/**
+ * Endpoint to test the Paid Memberships Pro Account page
+ */
 class Test_Account_Endpoint extends API_Endpoint {
 
 	// Trait to handle performance tracking
@@ -35,6 +38,15 @@ class Test_Account_Endpoint extends API_Endpoint {
 	 * @return WP_REST_Response
 	 */
 	public function handle_request( WP_REST_Request $request ) {
+
+		$method = $request->get_method();
+		if ( ! $this->is_request_allowed( $method ) ) {
+			return $this->json_error(
+				'method_not_allowed',
+				'The ' . $method . ' method is not allowed for this endpoint. Please adjust your toolkit settings.',
+				array( 'status' => 405 )
+			);
+		}
 
 		// Start performance tracking
 		$this->start_performance_tracking();

--- a/classes/api/Test_Cancel_Level_Endpoint.php
+++ b/classes/api/Test_Cancel_Level_Endpoint.php
@@ -51,6 +51,15 @@ class Test_Cancel_Level_Endpoint extends API_Endpoint {
 	 * @return WP_REST_Response
 	 */
 	public function handle_request( WP_REST_Request $request ) {
+		
+		$method = $request->get_method();
+		if ( ! $this->is_request_allowed( $method ) ) {
+			return $this->json_error(
+				'method_not_allowed',
+				'The ' . $method . ' method is not allowed for this endpoint. Please adjust your toolkit settings.',
+				array( 'status' => 405 )
+			);
+		}
 
 		// Start performance tracking
 		$this->start_performance_tracking();

--- a/classes/api/Test_Change_Level_Endpoint.php
+++ b/classes/api/Test_Change_Level_Endpoint.php
@@ -68,6 +68,16 @@ class Test_Change_Level_Endpoint extends API_Endpoint {
 	 * @return WP_REST_Response
 	 */
 	public function handle_request( WP_REST_Request $request ) {
+
+		$method = $request->get_method();
+		if ( ! $this->is_request_allowed( $method ) ) {
+			return $this->json_error(
+				'method_not_allowed',
+				'The ' . $method . ' method is not allowed for this endpoint. Please adjust your toolkit settings.',
+				array( 'status' => 405 )
+			);
+		}
+
 		$this->start_performance_tracking();
 
 		$params = $request->get_json_params();

--- a/classes/api/Test_Checkout_Endpoint.php
+++ b/classes/api/Test_Checkout_Endpoint.php
@@ -76,6 +76,16 @@ class Test_Checkout_Endpoint extends API_Endpoint {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function handle_request( WP_REST_Request $request ) {
+		
+		$method = $request->get_method();
+		if ( ! $this->is_request_allowed( $method ) ) {
+			return $this->json_error(
+				'method_not_allowed',
+				'The ' . $method . ' method is not allowed for this endpoint. Please adjust your toolkit settings.',
+				array( 'status' => 405 )
+			);
+		}
+
 		// Start metrics collection
 		$this->start_performance_tracking();
 

--- a/classes/api/Test_General_Endpoint.php
+++ b/classes/api/Test_General_Endpoint.php
@@ -37,8 +37,7 @@ class Test_General_Endpoint extends API_Endpoint {
 		);
 
 		// Check if the performance endpoints setting is enabled for read_write
-		global $pmprodev_options;
-		$performance_endpoints_setting = isset( $pmprodev_options['performance_endpoints'] ) ? $pmprodev_options['performance_endpoints'] : 'no';
+		$performance_endpoints_setting = method_exists( $this, 'check_setting' ) ? $this->check_setting( 'performance_endpoints' ) : 'no';
 
 		// Only register write method if read_write is enabled
 		if ( $performance_endpoints_setting === 'read_write' ) {

--- a/classes/api/Test_Login_Endpoint.php
+++ b/classes/api/Test_Login_Endpoint.php
@@ -82,6 +82,16 @@ class Test_Login_Endpoint extends API_Endpoint {
 	 * @return WP_REST_Response|WP_Error Response with performance metrics or error details.
 	 */
 	public function handle_request( WP_REST_Request $request ) {
+
+		$method = $request->get_method();
+		if ( ! $this->is_request_allowed( $method ) ) {
+			return $this->json_error(
+				'method_not_allowed',
+				'The ' . $method . ' method is not allowed for this endpoint. Please adjust your toolkit settings.',
+				array( 'status' => 405 )
+			);
+		}
+
 		// Start metrics collection first
 		$this->start_performance_tracking();
 

--- a/classes/api/Test_Member_Export_Endpoint.php
+++ b/classes/api/Test_Member_Export_Endpoint.php
@@ -84,6 +84,15 @@ class Test_Member_Export_Endpoint extends API_Endpoint {
 	 * @since 1.0.0
 	 */
 	public function handle_request( WP_REST_Request $request ) {
+		
+		$method = $request->get_method();
+		if ( ! $this->is_request_allowed( $method ) ) {
+			return $this->json_error(
+				'method_not_allowed',
+				'The ' . $method . ' method is not allowed for this endpoint. Please adjust your toolkit settings.',
+				array( 'status' => 405 )
+			);
+		}
 
 		// Raise WordPress memory limit
 		wp_raise_memory_limit( 'admin' );

--- a/classes/api/Test_Report_Endpoint.php
+++ b/classes/api/Test_Report_Endpoint.php
@@ -92,6 +92,15 @@ class Test_Report_Endpoint extends API_Endpoint {
 	 * @since 1.0.0
 	 */
 	public function handle_request( WP_REST_Request $request ) {
+		
+		$method = $request->get_method();
+		if ( ! $this->is_request_allowed( $method ) ) {
+			return $this->json_error(
+				'method_not_allowed',
+				'The ' . $method . ' method is not allowed for this endpoint. Please adjust your toolkit settings.',
+				array( 'status' => 405 )
+			);
+		}
 
 		// Raise WordPress memory limit
 		wp_raise_memory_limit( 'admin' );

--- a/classes/api/Test_Search_Endpoint.php
+++ b/classes/api/Test_Search_Endpoint.php
@@ -59,6 +59,16 @@ class Test_Search_Endpoint extends API_Endpoint {
 	 * @return WP_REST_Response
 	 */
 	public function handle_request( WP_REST_Request $request ) {
+
+		$method = $request->get_method();
+		if ( ! $this->is_request_allowed( $method ) ) {
+			return $this->json_error(
+				'method_not_allowed',
+				'The ' . $method . ' method is not allowed for this endpoint. Please adjust your toolkit settings.',
+				array( 'status' => 405 )
+			);
+		}
+		
 		$search_query = sanitize_text_field( $request->get_param( 'query' ) );
 		$type         = sanitize_text_field( $request->get_param( 'type' ) );
 


### PR DESCRIPTION
- Added "is_request_allowed" to check the PMPro toolkit protocol settings to ensure that it only allows the methods based on toolkit settings.

The reason it's done inside the `handle_request` method is to be an extra guard rail, and show a better error message than "not at all". While it makes sense to also only register the routes when the "read_write" is enabled, this is purely a clearer indication of "why" this route isn't returning or processing data. Not registering the route based on settings returns a 404 error and can be a bit confusing to developers without knowing that you need to enable read_write options.

It _can_ go either way, this felt like a better user approach due to error messaging when options don't align.

### How to test the changes in this Pull Request:

1. Before testing this PR, set the "Performance Testing Endpoints" to "read only".
2. Test a POST endpoint, such as `/wp-json/toolkit/v1/test-checkout` and see that it actually processes and runs. (You have to be authenticated).
3. Apply this PR to your dev site, rerun the test and see that an error is returned. After this, turn on the setting to "Read and Write" and see that it processes correctly.