### PR TITLE
Drop is_plugin_active() guard in favor of per-function PMPro checks

### DIFF
--- a/pmpro-toolkit.php
+++ b/pmpro-toolkit.php
@@ -13,11 +13,6 @@ defined( 'ABSPATH' ) || exit;
 
 define( 'PMPRO_TOOLKIT_VERSION', '1.1.1' );
 
-// If Paid Membership Pro is not active do nothing
-if ( ! is_plugin_active( 'paid-memberships-pro/paid-memberships-pro.php' ) ) {
-	return;
-}
-
 /*
 * Globals
 */
@@ -71,7 +66,7 @@ require_once PMPRODEV_DIR . '/classes/class-pmprodev-migration-assistant.php';
  * @return void
  * @since 1.1
  */
-if ( ! empty( $pmprodev_options['performance_endpoints'] ) && $pmprodev_options['performance_endpoints'] !== 'no' ) {
+if ( ! empty( $pmprodev_options['performance_endpoints'] ) && $pmprodev_options['performance_endpoints'] !== 'no' && function_exists( 'pmpro_getOption' ) ) {
 	// Explicitly load the API Loader class.
 	require_once plugin_dir_path( __FILE__ ) . 'classes/class-api-loader.php';
 	// Load the API Performance Tracking Trait.
@@ -93,7 +88,7 @@ if ( ! empty( $pmprodev_options['performance_endpoints'] ) && $pmprodev_options[
  * @return void
  * @since 1.1
  */
-if ( defined( 'WP_CLI' ) && WP_CLI && ! empty( $pmprodev_options['enable_cli_commands'] ) ) {
+if ( defined( 'WP_CLI' ) && WP_CLI && ! empty( $pmprodev_options['enable_cli_commands'] ) && function_exists( 'pmpro_getOption' ) ) {
 	// Load CLI command class only if enabled via Toolkit setting.
 	require_once plugin_dir_path( __FILE__ ) . 'cli/Toolkit_Commands.php';
 	\WP_CLI::add_command( 'pmpro-toolkit', 'PMPro_Toolkit\\Toolkit_Commands' );
@@ -337,6 +332,9 @@ function pmprodev_admin_menu_bar( $wp_admin_bar ) {
  * @since 1.0
  */
 function pmprodev_process_migration_export() {
+	if ( ! function_exists( 'pmpro_getAllLevels' ) ) {
+		return;
+	}
 	if ( ! empty( $_REQUEST['page'] ) && 'pmpro-toolkit' === $_REQUEST['page'] && ! empty( $_REQUEST['section'] )
 	&& 'migration' === $_REQUEST['section'] && ! empty( $_REQUEST['pmprodev_export_options'] ) ) {
 		PMProDev_Migration_Assistant::export( $_REQUEST['pmprodev_export_options'] );
@@ -351,6 +349,9 @@ add_action( 'admin_init', 'pmprodev_process_migration_export' );
  * @since 1.0
  */
 function pmprodev_settings_page() {
+	if ( ! function_exists( 'pmpro_getParam' ) ) {
+		return;
+	}
 	require_once plugin_dir_path( __FILE__ ) . '/adminpages/toolkit.php';
 }
 


### PR DESCRIPTION
## Summary

Fixes #68 — the top-of-file `is_plugin_active( 'paid-memberships-pro/paid-memberships-pro.php' )` early return failed when PMPro was installed under a non-standard folder name (e.g. release-candidate zips like `paid-memberships-pro-rc1`) and could fatal on frontend requests since `is_plugin_active()` lives in `wp-admin/includes/plugin.php`.

Replaces it with narrow `function_exists()` checks at each entry point that actually depends on PMPro:

- **API loader registration** — gated on `pmpro_getOption()` so the `/toolkit/v1/*` REST endpoints (whose handlers call `pmpro_loadTemplate` / `pmpro_getLevel` / `pmpro_changeMembershipLevel` / use `PMPRO_DIR`) are not registered when PMPro is not loaded.
- **WP-CLI commands registration** — same gate, so toolkit CLI commands (which load `adminpages/scripts.php` referencing `$wpdb->pmpro_*` and calling `pmpro_changeMembershipLevel` etc.) are not registered.
- **`pmprodev_process_migration_export()`** — gated on `pmpro_getAllLevels()` since `PMProDev_Migration_Assistant::export()` calls it.
- **`pmprodev_settings_page()`** — gated on `pmpro_getParam()` since `adminpages/toolkit.php` uses `PMPRO_DIR` and `pmpro_getParam` at parse time.

Other handlers do not need guards:

- `pmprodev_checkout_debug_email` already self-guards with `function_exists( 'pmpro_is_checkout' )`.
- `pmprodev_gateway_debug_setup` is already defensive with `class_exists` checks and harmless `define()` / `remove_action()` calls.
- `pmprodev_admin_menu` / `pmprodev_admin_menu_bar` silently no-op when their PMPro parent menu does not exist.
- The rest (`pmprodev_init_options`, `pmprodev_redirect_emails`, `pmpro_toolkit_load_textdomain`, `pmprodev_plugin_row_meta`, `pmprodev_enqueue_scripts`, `pmprodev_enqueue_admin_scripts`, `pmprodev_create_button`) are either purely toolkit-internal or only fire via PMPro hooks.

## Test plan

- [ ] Install Toolkit with PMPro active under a non-standard folder name (e.g. `paid-memberships-pro-rc1`) — Toolkit features (settings page, debug emails, migration assistant) should all work.
- [ ] Install Toolkit without PMPro active — no fatal errors on frontend, admin, REST, or WP-CLI.
- [ ] With Toolkit performance endpoints enabled, deactivate PMPro — `/wp-json/toolkit/v1/*` should 404 instead of fataling.
- [ ] With Toolkit CLI commands enabled, deactivate PMPro — `wp pmpro-toolkit <cmd>` should report "Command not found" instead of fataling.
- [ ] Settings page (`?page=pmpro-toolkit`) loads cleanly under all combinations.
- [ ] Migration export still works under normal install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)