### PR TITLE
Require authentication for performance test REST endpoints

### DIFF
--- a/classes/api/Abstract_API_Endpoint.php
+++ b/classes/api/Abstract_API_Endpoint.php
@@ -45,12 +45,12 @@ abstract class API_Endpoint {
 
 	/**
 	 * Default permission callback for endpoints.
-	 * Requires authentication by default.
+	 * Requires an authenticated administrator by default.
 	 *
 	 * @return bool
 	 */
 	public function handle_permissions() {
-		return is_user_logged_in();
+		return current_user_can( 'manage_options' );
 	}
 
 

--- a/classes/api/Abstract_API_Endpoint.php
+++ b/classes/api/Abstract_API_Endpoint.php
@@ -56,6 +56,32 @@ abstract class API_Endpoint {
 
 
 	/**
+	 * Permission callback for endpoints that previously allowed unauthenticated access.
+	 *
+	 * Defaults to requiring an authenticated administrator. Unauthenticated access must be
+	 * explicitly enabled with the pmpro_toolkit_allow_unauthenticated_requests filter, in
+	 * which case IP throttling applies if enabled.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function handle_permissions_with_unauthenticated_opt_in() {
+		/**
+		 * Filter whether unauthenticated requests are allowed for performance test endpoints.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool          $allow    Whether to allow unauthenticated requests. Default false.
+		 * @param API_Endpoint  $endpoint The endpoint instance being checked.
+		 */
+		if ( ! apply_filters( 'pmpro_toolkit_allow_unauthenticated_requests', false, $this ) ) {
+			return current_user_can( 'manage_options' );
+		}
+		return $this->throttle_if_unauthenticated();
+	}
+
+	/**
 	 * Standard JSON success response
 	 *
 	 * @param array $data

--- a/classes/api/Test_Account_Endpoint.php
+++ b/classes/api/Test_Account_Endpoint.php
@@ -22,7 +22,7 @@ class Test_Account_Endpoint extends API_Endpoint {
 			'/test-account-page',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'permission_callback' => array( $this, 'handle_permissions' ), // inherits from Abstract_API_Endpoint (require authentication)
+				'permission_callback' => 'is_user_logged_in', // Only acts on the current user, so load tests can authenticate as the member being profiled.
 				'callback'            => array( $this, 'handle_request' ),
 			)
 		);

--- a/classes/api/Test_Cancel_Level_Endpoint.php
+++ b/classes/api/Test_Cancel_Level_Endpoint.php
@@ -19,7 +19,7 @@ class Test_Cancel_Level_Endpoint extends API_Endpoint {
 			'/test-cancel-level',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'permission_callback' => array( $this, 'handle_permissions' ), // inherits from Abstract_API_Endpoint (require authentication)
+				'permission_callback' => 'is_user_logged_in', // Only acts on the current user, so load tests can authenticate as the member being profiled.
 				'callback'            => array( $this, 'handle_request' ),
 			)
 		);

--- a/classes/api/Test_Change_Level_Endpoint.php
+++ b/classes/api/Test_Change_Level_Endpoint.php
@@ -26,13 +26,14 @@ class Test_Change_Level_Endpoint extends API_Endpoint {
 	}
 
 	/**
-	 * Permission callback for the endpoint. Unauthenticated access is allowed, but
-	 * rate limiting is applied based on IP address.
+	 * Permission callback for the endpoint. Requires an authenticated administrator
+	 * unless unauthenticated access is explicitly enabled via the
+	 * pmpro_toolkit_allow_unauthenticated_requests filter.
 	 *
 	 * @return bool|WP_Error
 	 */
 	public function handle_permissions() {
-		return $this->throttle_if_unauthenticated();
+		return $this->handle_permissions_with_unauthenticated_opt_in();
 	}
 
 	/**

--- a/classes/api/Test_Checkout_Endpoint.php
+++ b/classes/api/Test_Checkout_Endpoint.php
@@ -28,13 +28,14 @@ class Test_Checkout_Endpoint extends API_Endpoint {
 	}
 
 	/**
-	 * Permission callback for the endpoint. Unauthenticated access is allowed, but
-	 * rate limiting is applied based on IP address.
+	 * Permission callback for the endpoint. Requires an authenticated administrator
+	 * unless unauthenticated access is explicitly enabled via the
+	 * pmpro_toolkit_allow_unauthenticated_requests filter.
 	 *
 	 * @return bool|WP_Error
 	 */
 	public function handle_permissions() {
-		return $this->throttle_if_unauthenticated();
+		return $this->handle_permissions_with_unauthenticated_opt_in();
 	}
 
 	/**

--- a/classes/api/Test_General_Endpoint.php
+++ b/classes/api/Test_General_Endpoint.php
@@ -54,13 +54,14 @@ class Test_General_Endpoint extends API_Endpoint {
 	}
 
 	/**
-	 * Permission callback for the endpoint. Unauthenticated access is allowed, but
-	 * rate limiting is applied based on IP address.
+	 * Permission callback for the endpoint. Requires an authenticated administrator
+	 * unless unauthenticated access is explicitly enabled via the
+	 * pmpro_toolkit_allow_unauthenticated_requests filter.
 	 *
 	 * @return bool|WP_Error
 	 */
 	public function handle_permissions() {
-		return $this->throttle_if_unauthenticated();
+		return $this->handle_permissions_with_unauthenticated_opt_in();
 	}
 
 	/**

--- a/classes/api/Test_Login_Endpoint.php
+++ b/classes/api/Test_Login_Endpoint.php
@@ -32,13 +32,14 @@ class Test_Login_Endpoint extends API_Endpoint {
 	}
 
 	/**
-	 * Permission callback for the endpoint. Unauthenticated access is allowed, but
-	 * rate limiting is applied based on IP address.
+	 * Permission callback for the endpoint. Requires an authenticated administrator
+	 * unless unauthenticated access is explicitly enabled via the
+	 * pmpro_toolkit_allow_unauthenticated_requests filter.
 	 *
 	 * @return bool|WP_Error
 	 */
 	public function handle_permissions() {
-		return $this->throttle_if_unauthenticated();
+		return $this->handle_permissions_with_unauthenticated_opt_in();
 	}
 
 	/**

--- a/classes/class-api-loader.php
+++ b/classes/class-api-loader.php
@@ -83,8 +83,8 @@ class API_Loader {
 		if ( ! empty( $user ) ) {
 			return $user;
 		}
-		// Only run on REST API requests.
-		if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {
+		// Only run on REST API requests for Toolkit endpoints.
+		if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST || ! $this->is_toolkit_rest_request() ) {
 			return $user;
 		}
 		// Only attempt if PHP_AUTH_USER and PHP_AUTH_PW are set.
@@ -129,6 +129,10 @@ class API_Loader {
 	 * @return bool|WP_Error True if authenticated, WP_Error if not.
 	 */
 	public function hybrid_basic_auth( $result ) {
+		// Only run for Toolkit endpoints.
+		if ( ! $this->is_toolkit_rest_request() ) {
+			return $result;
+		}
 		// Only override invalid application password errors.
 		if ( is_wp_error( $result ) && $result->get_error_code() === 'incorrect_password' ) {
 			if (
@@ -143,5 +147,20 @@ class API_Loader {
 			}
 		}
 		return $result;
+	}
+
+	/**
+	 * Check whether the current REST request targets a Toolkit endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	protected function is_toolkit_rest_request() {
+		if ( empty( $_SERVER['REQUEST_URI'] ) ) {
+			return false;
+		}
+		$request_uri = esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
+		return false !== strpos( $request_uri, '/' . rest_get_url_prefix() . '/' . API_Endpoint::$namespace . '/' );
 	}
 }

--- a/classes/class-api-loader.php
+++ b/classes/class-api-loader.php
@@ -157,10 +157,13 @@ class API_Loader {
 	 * @return bool
 	 */
 	protected function is_toolkit_rest_request() {
-		if ( empty( $_SERVER['REQUEST_URI'] ) ) {
+		// Use the rest_route query var rather than REQUEST_URI: it is set for both pretty
+		// and plain (?rest_route=) permalinks, and it reflects the route actually being
+		// dispatched, so it can't be spoofed by including the Toolkit path elsewhere in the URL.
+		if ( empty( $GLOBALS['wp']->query_vars['rest_route'] ) ) {
 			return false;
 		}
-		$request_uri = esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
-		return false !== strpos( $request_uri, '/' . rest_get_url_prefix() . '/' . API_Endpoint::$namespace . '/' );
+		$rest_route = '/' . ltrim( $GLOBALS['wp']->query_vars['rest_route'], '/' );
+		return 0 === strpos( $rest_route, '/' . API_Endpoint::$namespace . '/' );
 	}
 }


### PR DESCRIPTION
Found during an authorization audit in the wake of CVE-2026-19598 (Pods). Two issues in the performance testing REST API:

## Unauthenticated write endpoints

When `performance_endpoints` is `read_write`, the permission callbacks for `test-change-level`, `test-checkout`, `test-login`, and `test` returned `throttle_if_unauthenticated()` — which is `true` for everyone unless IP throttling is separately enabled (default: off). An unauthenticated caller could:

- **`test-change-level`** — `wp_set_current_user()` to any user by login/email and run a full level change as them
- **`test-checkout`** — `wp_insert_user()` with attacker-supplied credentials and create orders
- **`test-login`** — password verification oracle against arbitrary user/pass pairs with no rate limiting

**Fix:** these endpoints now require an authenticated `manage_options` user. Unauthenticated access requires an explicit opt-in via the new `pmpro_toolkit_allow_unauthenticated_requests` filter, and IP throttling still applies in that mode.

## Site-wide Basic Auth filters

`API_Loader` registered `determine_current_user` and `rest_authentication_errors` handlers globally whenever performance endpoints were enabled. `basic_auth_user()` accepted any account's **regular password** via Basic Auth on any REST route, and `hybrid_basic_auth()` retried failed app-password auth against the account password — silently defeating Application Passwords hardening (revocable, scoped credentials) site-wide.

**Fix:** both handlers now only run for requests under the `toolkit/v1` namespace. The password fallback remains available for Toolkit endpoints (load-testing workflows) but no longer weakens the rest of the REST API.

**Testing:** with performance endpoints enabled and set to read_write: (1) `POST /wp-json/toolkit/v1/test-checkout` unauthenticated → 401/403; (2) same request as an admin (app password or cookie+nonce) → works as before; (3) add `add_filter( 'pmpro_toolkit_allow_unauthenticated_requests', '__return_true' );` → unauthenticated requests work again, throttled if enabled; (4) Basic Auth with a regular account password against a non-toolkit REST route (e.g. `/wp-json/wp/v2/posts`) → no longer authenticates.